### PR TITLE
Add option to skip errors when no matches are found

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,4 +15,6 @@ pub struct Settings {
     pub selected_file_types: Vec<String>,
     /// List of file types to ignore (default: empty)
     pub ignored_file_types: Vec<String>,
+    /// Exits without an error when no matches are found (default: false)
+    pub allow_empty: bool,
 }


### PR DESCRIPTION
Adding a new option `--allow-empty` that, when supplied and no matches are found, prints the "No matches" -information and then exits _without_ error (code 0).

My use case is similar to #104 where I run ruplacer as a pre-build task on some source code, and it typically only replaces when someone else made changes. I don't want subsequent attemps to necessarily throw errors, as the replacement has already been made.

Fixes #104 