### PR TITLE
Add a test case and doc for `${1}` group reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ ruplacer '(\w+), (\w+)' '$2 $1'
 
 (note the use of single quotes to avoid any processing by the shell)
 
+`${1}` and `${2}` are also supported as an alternative to `$1` and `$2`, see
+[reference
+here](https://docs.rs/regex/1.5.5/regex/struct.Regex.html#replacement-string-syntax).
+Useful if the replacement string is immediately adjacent to literal text.
 
 If you don't want the pattern to be used as a regex, use the `--no-regex` command line flag.
 

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -362,9 +362,10 @@ mod tests {
     fn test_regex_with_substitutions() {
         let input = "first, second";
         let regex = Regex::new(r"(\w+), (\w+)").unwrap();
-        let query = Query::regex(regex, r"$2 $1");
+        // ensure ${1}text syntax works as expected
+        let query = Query::regex(regex, r"$2 ${1}third");
         let replacement = replace(input, &query).unwrap();
-        assert_eq!(replacement.output(), "second first");
+        assert_eq!(replacement.output(), "second firstthird");
     }
 
     #[test]


### PR DESCRIPTION
Alternate form supported by the regex crate.